### PR TITLE
fix: Reinstate cargo cdylib build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Cargo build
 **/target
+**/dist-newstyle
 
 # MacOS nuisances
 .DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
This enables `cargo repl` to work again, and might (hopefully) fix the macos build issues