### PR TITLE
add extra-source-files to allow building as external dep

### DIFF
--- a/plonk-verify.cabal
+++ b/plonk-verify.cabal
@@ -40,6 +40,7 @@ version:            0.1.0
 -- A copyright notice.
 -- copyright:
 
+extra-source-files: Cargo.toml Cargo.lock src/lib.rs
 
 -- This let us hook Cabal steps to Setup.lhs script.
 build-type:         Custom


### PR DESCRIPTION
We need to list the external sources, otherwise we can't build `lurk-hs` as external dependency. 