### PR TITLE
feat: Update documentation with detailed logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,22 @@ Download the installer from https://go.dev/dl/ and follow the installation instr
 ```
 
 ### 2. Install Rust
-Make sure you have Rust installed by following the instructions [here](https://rustup.rs/)..
+Make sure you have Rust installed by following the instructions [here](https://rustup.rs/).
+
+## Logging Configuration
+
+The verifier uses two logging systems:
+
+- Rust logging via `tokio-tracing`, configured through the `RUST_LOG` environment variable. See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for detailed configuration options.
+- Go logging for FFI calls, configured through the `SP1_GO_LOG` environment variable.
+
+To set a global log level (e.g. warn), configure both variables:
+
+```bash
+RUST_LOG=warn SP1_GO_LOG=warn ./plonk-verify ...
+```
+
+Valid log levels are: error, warn, info, debug, trace
 
 ### 3. Install Haskell (Cabal)
 Ensure that you have Haskell and Cabal installed by following the instructions [here](https://www.haskell.org/cabal/).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To set a global log level (e.g. warn), configure both variables:
 RUST_LOG=warn SP1_GO_LOG=warn ./plonk-verify ...
 ```
 
-Valid log levels are: error, warn, info, debug, trace
+Valid log levels are: error, warn, info, debug, trace, off
 
 ### 3. Install Haskell (Cabal)
 Ensure that you have Haskell and Cabal installed by following the instructions [here](https://www.haskell.org/cabal/).


### PR DESCRIPTION
After https://github.com/argumentcomputer/sphinx/pull/193

- Resolve a typo error in instructions set for Rust installation
- Enhance README.md file with extensive details about the two logging systems used in our software - Rust's `tokio-tracing` and Go for FFI calls
- Provide complete direction to users on methods to setup a unified log level for both logging systems
- Enumerate all applicable log levels: error, warn, info, debug, and trace for user reference.